### PR TITLE
Display arrival times

### DIFF
--- a/app/Api.elm
+++ b/app/Api.elm
@@ -2,5 +2,4 @@ module Api exposing (..)
 
 
 baseUrl =
-    -- "https://purpletrainapp.com"
-    "http://localhost:4000"
+    "https://purpletrainapp.com"

--- a/app/Api.elm
+++ b/app/Api.elm
@@ -2,4 +2,5 @@ module Api exposing (..)
 
 
 baseUrl =
-    "https://purpletrainapp.com"
+    -- "https://purpletrainapp.com"
+    "http://localhost:4000"

--- a/app/FetchSchedule.elm
+++ b/app/FetchSchedule.elm
@@ -33,8 +33,9 @@ decodeSchedule =
 
 decodeTrain : Decode.Decoder Train
 decodeTrain =
-    Decode.map5 Train
+    Decode.map6 Train
         (Decode.field "scheduled_departure_utc" stringToDate)
+        (Decode.field "scheduled_arrival_utc" stringToDate)
         (Decode.maybe (Decode.field "predicted_departure_utc" stringToDate))
         (Decode.maybe (Decode.field "track" Decode.string))
         (Decode.maybe (Decode.field "coach_number" Decode.string))

--- a/app/Schedule/View.elm
+++ b/app/Schedule/View.elm
@@ -120,6 +120,7 @@ nextTrainMetadata direction now train =
         (catMaybes
             [ trainInfo direction train
             , Just (prediction now train)
+            , Just (arrival now train)
             ]
         )
 
@@ -168,14 +169,18 @@ trainMetadata string =
 trainMetadataWithColor : String -> String -> Node Msg
 trainMetadataWithColor string color =
     text
-        [ Ui.style
-            [ Style.color color
-            , Style.marginBottom <| scale 5
-            , Style.fontSize <| scale 12
-            , Style.textAlign "right"
-            ]
-        ]
+        [ metadataStyle color ]
         [ Ui.string <| string ]
+
+
+metadataStyle : String -> Property Msg
+metadataStyle color =
+    Ui.style
+        [ Style.color color
+        , Style.marginBottom <| scale 5
+        , Style.fontSize <| scale 12
+        , Style.textAlign "right"
+        ]
 
 
 laterTrainView : Date -> Train -> Node Msg
@@ -267,6 +272,16 @@ predictionColor minutesLate =
 
         Just _ ->
             Color.red
+
+
+arrival : Date -> Train -> Node Msg
+arrival date train =
+    trainMetadata ("arrives at" ++ arrivalTime train)
+
+
+arrivalTime : Train -> String
+arrivalTime train =
+    prettyTime train.scheduledArrival
 
 
 suppressHighlighting : Bool -> Property msg

--- a/app/Schedule/View.elm
+++ b/app/Schedule/View.elm
@@ -278,7 +278,7 @@ predictionColor minutesLate =
 
 arrival : Date -> Train -> Node Msg
 arrival date train =
-    trainMetadata ("arrives at" ++ arrivalTime train)
+    trainMetadata ("arrives at " ++ arrivalTime train)
 
 
 arrivalTime : Train -> String

--- a/app/Types.elm
+++ b/app/Types.elm
@@ -16,6 +16,7 @@ type alias Schedule =
 
 type alias Train =
     { scheduledDeparture : Date
+    , scheduledArrival : Date
     , predictedDeparture : Maybe Date
     , track : Maybe String
     , coach : Maybe String


### PR DESCRIPTION
When a train leaves the station it has to stop somewhere. We should assume
it's going to stop where you're intending to go. On the Elixir side, we're
including the arrival time of the train (as per
thoughtbot/purple_train_web#48). This commit displays this arrival time just
below the departure time. It currently messes up the layout a bit but that can
be modified.

This must be applied AFTER
https://github.com/thoughtbot/purple_train_web/pull/48 or we'll get errors.

Inbound: 
![screen shot 2017-03-20 at 2 45 50 pm](https://cloud.githubusercontent.com/assets/4632/24116240/872c4918-0d7c-11e7-8c91-e6b97d38b9c6.png)

Outbound: 
![screen shot 2017-03-20 at 2 45 45 pm](https://cloud.githubusercontent.com/assets/4632/24116245/8c092e10-0d7c-11e7-972a-dcdfa0238430.png)

